### PR TITLE
Build project with type error

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -168,6 +168,24 @@ class ApiClient {
   async makeRequest<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
     return this.request<T>(endpoint, options);
   }
+
+  // Generic HTTP helpers -----------------------------------------
+  // These helpers make it easier to use the ApiClient in a REST-like
+  // fashion from other modules without needing to manually specify the
+  // RequestInit object each time.
+  async get<T = any>(endpoint: string, queryParams?: Record<string, string>): Promise<{ data: T }> {
+    const data = await this.request<T>(endpoint, {}, queryParams);
+    return { data };
+  }
+
+  async post<T = any>(endpoint: string, data?: any, queryParams?: Record<string, string>): Promise<{ data: T }> {
+    const options: RequestInit = {
+      method: 'POST',
+      body: data !== undefined ? JSON.stringify(data) : undefined,
+    };
+    const responseData = await this.request<T>(endpoint, options, queryParams);
+    return { data: responseData };
+  }
 }
 
 // Export singleton instance


### PR DESCRIPTION
Add `get` and `post` methods to `ApiClient` to resolve a TypeScript compilation error.

The build was failing because `src/services/impact-intelligence.ts` attempted to use `apiClient.get()` and `apiClient.post()`, but these methods were not defined on the `ApiClient` class. This PR adds these generic Axios-style helpers, wrapping the existing `request` method, to enable successful compilation.

---

[Open in Web](https://www.cursor.com/agents%3Fid=bc-07206d3a-2f62-4e73-92d3-5137169814b1) • [Open in Cursor](https://cursor.com/background-agent%3FbcId=bc-07206d3a-2f62-4e73-92d3-5137169814b1)